### PR TITLE
Add default case for switch statements

### DIFF
--- a/chukonu_rest/src/main/java/net/yxy/chukonu/rest/WSAuthenticationClient.java
+++ b/chukonu_rest/src/main/java/net/yxy/chukonu/rest/WSAuthenticationClient.java
@@ -61,7 +61,12 @@ public class WSAuthenticationClient {
 					           
 					            authCache.put(targetHost, digestAuth);
 					            break ;
-				case "NTLM":	
+				case "NTLM":
+				//missing default case
+        			default:
+            			    // add default case
+            				break;
+
 			}
 			
 	


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html